### PR TITLE
Add browserify as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^15.3.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.16.0"
+    "babel-cli": "^6.16.0",
+    "browserify": "^13.1.1"
   }
 }


### PR DESCRIPTION
It's always better to not rely the build on globally available executables and list them as project dependencies instead.
